### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/chench/f13f3304-421d-4abc-8eec-b4a9960c5b9c/7b077374-5ad4-45ec-8bd6-99cae929d488/_apis/work/boardbadge/1246c4c7-f249-4ab7-ab9b-70f6d8f70726)](https://codedev.ms/chench/f13f3304-421d-4abc-8eec-b4a9960c5b9c/_boards/board/t/7b077374-5ad4-45ec-8bd6-99cae929d488/Microsoft.RequirementCategory)
 # orgrepo1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/chench/f13f3304-421d-4abc-8eec-b4a9960c5b9c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.